### PR TITLE
Increase test coverage to 100%

### DIFF
--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -1,6 +1,21 @@
 import { sanitizeArray, sanitizeObject, sanitizeString } from "./sanitize";
 
+var mockedLibrary: any;
+
+jest.mock("dompurify", () => {
+  return function (windowEmulator: any) {
+    mockedLibrary = {
+      ...jest.requireActual("dompurify")(windowEmulator),
+    };
+    return mockedLibrary;
+  }
+});
+
 describe("Test sanitization utilities", () => {
+  beforeAll(() => {
+    mockedLibrary.isSupported = true;
+  });
+
   it("should correctly sanitize strings", () => {
     expect(sanitizeString("<a href='&#x2000;javascript:alert(1)'>")).toEqual(
       "<a></a>"
@@ -14,6 +29,14 @@ describe("Test sanitization utilities", () => {
       ])
     ).toEqual(["<a></a>", "<a></a>"]);
   });
+  it("should correctly sanitize nested arrays", () => {
+    expect(
+      sanitizeArray([[
+        "<a href='&#x2000;javascript:alert(1)'>",
+        "<a href='&#x2000;javascript:alert(2)'>",
+      ]])
+    ).toEqual([["<a></a>", "<a></a>"]]);
+  });
   it("should correctly sanitize an object", () => {
     expect(
       sanitizeObject({
@@ -22,4 +45,28 @@ describe("Test sanitization utilities", () => {
       })
     ).toEqual({ foo: "<a></a>", bar: "<a></a>" });
   });
+  it("should not alter non-strings", () => {
+    expect(
+      sanitizeObject({
+        foo: false,
+        bar: 5,
+      })
+    ).toEqual({ foo: false, bar: 5 });
+  });
 });
+
+describe("test sanitization utilities in obsolete environments", () => {
+  beforeAll(() => {
+    mockedLibrary.isSupported = false;
+  });
+
+  it("should null out strings", () => {
+    expect(sanitizeString("asdf")).toBeNull();
+  });
+  it("should null out strings in arrays", () => {
+    expect(sanitizeArray(["asdf", 5])).toEqual([null, 5]);
+  });
+  it("should null out string properties of objects", () => {
+    expect(sanitizeObject({ foo: "asdf", bar: 5 })).toEqual({ foo: null, bar: 5 });
+  });
+})

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -40,7 +40,12 @@ const sanitizerMap: any = {
 const sanitizeEntry = (entry: unknown) => {
   const entryType = Array.isArray(entry) ? "array" : typeof entry;
   const sanitizer = sanitizerMap[entryType];
-  return sanitizer?.(entry) || entry;
+  if (sanitizer) {
+    return sanitizer(entry);
+  }
+  else {
+    return entry;
+  }
 };
 
 // Return true if the string is only whitespace; false otherwise.

--- a/src/validation/schemas/number.test.ts
+++ b/src/validation/schemas/number.test.ts
@@ -17,6 +17,10 @@ describe("Test number schema", () => {
     expect(schema.isValidSync(null)).toBe(false);
     expect(schema.isValidSync("!@#!@%")).toBe(false);
     expect(schema.isValidSync("abc")).toBe(false);
+    expect(schema.isValidSync("$123")).toBe(true);
+    expect(schema.isValidSync("1$23")).toBe(false);
+    expect(schema.isValidSync("123%")).toBe(true);
+    expect(schema.isValidSync("12%3")).toBe(false);
   });
 
   it("should correctly validate optional number fields", () => {


### PR DESCRIPTION
### Description
Nothing fancy here. I pulled a bit of a weird hack to emulate a lack of support for `DOMPurify`. And in running my tests, I found a bug:
1. We signal support for sanitization by returning `null` instead of a sanitized string
2. We determine whether to sanitize a value based on whether we can find a sanitizer
3. We were checking both of these checks into a single line - so that when we couldn't support sanitization, we were passing values through unchanged (for arrays and objects)

### Related ticket(s)
n/a

---
### How to test
```bash
yarn test --coverage
```

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
