### PR TITLE
Create workflow to publish to NPM automatically

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+      - run: yarn build
+      - run: yarn npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,19 @@
 {
-  "name": "mdct-core",
-  "version": "1.0.0",
-  "description": "",
+  "name": "@enterprise-cmcs/mdct-core",
+  "license": "CC0-1.0",
+  "version": "0.1.0",
+  "description": "Core functionality used across CMS MDCT applications",
+  "keywords": ["cms", "cmcs", "mdct"],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "repository": {
+    "type": "git",
+    "directory": "https://github.com/Enterprise-CMCS/macpro-mdct-core.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "coverage": "jest --coverage",
     "test": "jest --setupFiles dotenv/config",
@@ -74,7 +84,6 @@
       "<rootDir>/setupJest.ts"
     ]
   },
-  "license": "ISC",
   "dependencies": {
     "aws-amplify": "^4.3.4",
     "date-fns": "^2.26.0",


### PR DESCRIPTION
### Description
This PR creates a workflow to publish Core as an NPM package, whenever we create a published release through the Github web UI. It also populates several fields in the package.json that will be relevant to the publish. At the same time, Brax has created the needed NPM_TOKEN as a Github Secret.

I give this like a 30% chance of working, let's see.

### Related ticket(s)
n/a

---
### How to test
Create a release in the Github UI. Actually don't, I will.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://bit.ly/3zPrxuZ) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
  If this works, I'll document the release process in the README.
---
