### PR TITLE
fix(small change to trigger and publish npm): pushing a small change to trigger a build to publish on merge to main

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # gives temp GITHUB_TOKEN without setting in github actions secrets explicitly
+    # gives temp GITHUB_TOKEN without setting in github actions secrets explicitly.
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
### Description
I messed up the squash and merge commit message therefore it did not trigger a publish to npm. This is an extremely small PR to confirm that build and publish behavior on merge to the integration branch (main)


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-2934

---
### How to test
recommended for PR's intended to release the package to just give the pr title your desired commit message so its picked up without changing upon merge. 


### Important updates
n/a


---
### Author checklist
n/a

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
