### PR TITLE
Add version number build badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@
 [![npm version](https://badge.fury.io/js/@enterprise-cmcs%2Fmdct-core.svg)](https://badge.fury.io/js/@enterprise-cmcs%2Fmdct-core) [![Maintainability](https://api.codeclimate.com/v1/badges/3dd8c47fb161adc36946/maintainability)](https://codeclimate.com/repos/64f79f2cb94c0076558d5147/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/3dd8c47fb161adc36946/test_coverage)](https://codeclimate.com/repos/64f79f2cb94c0076558d5147/test_coverage)
 
 
-### How to publish this package
+### How to publish this package to npm
 The mdct-core npm package uses semantic-release to publish packages to the enterprise-cmcs npm org. To read more about semantic release please visit the following link: https://github.com/semantic-release/semantic-release
 
-The publish workflow will run only when pull requests are merged into the main branch and the mechanism for publishing relies on the commit message to trigger a publishing build based on a few key words. 
+The publish workflow will run only when pull requests are merged into the **main branch** and the mechanism for publishing relies on the commit message to trigger a publishing build based on a few key words. 
 
-the 3 keywords for semantic release are as following:
+**the 3 keywords for semantic release are as following:**
 
-"fix": this will up the patch version of the release number (note: semantic release calls patch a fix release)
+* **"fix"**: this will up the patch version of the release number (note: semantic release calls patch a fix release)
 
-"feat": this will update the minor version of the release number (note: semantic release calls this a feature release)
+* **"feat"**: this will update the minor version of the release number (note: semantic release calls this a feature release)
 
-"perf": this will update the major version of the release number (note: semantic release calls this a breaking release)
+* **"perf"**: this will update the major version of the release number (note: semantic release calls this a breaking release)
 
 For example: 
 
 fix(publishing from CI): my commit message of choice
+
+**note:** the commit message needs to be on the merge commit when merging into main


### PR DESCRIPTION
### Description
For easier consumption of the currently published version of the @enterprise-cmcs/mdct-core npm package on npm the desire is to add a build badge. This PR does that and cleans up the other badges from code climate to be more clean

In addition language was added to the README to give instructions on how to publish new versions to npm using semantic release

### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3133

---
### How to test
look at the README on this branch to confirm build badge looks good and language looks good for publishing a new npm package to npm. 


### Important updates
none

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
