### PR TITLE
fix: updating package version badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @enterprise-cmcs/mdct-core
 
-[![npm version](https://badge.fury.io/js/@enterprise-cmcs%2Fmdct-core.svg)](https://badge.fury.io/js/@enterprise-cmcs%2Fmdct-core) [![Maintainability](https://api.codeclimate.com/v1/badges/3dd8c47fb161adc36946/maintainability)](https://codeclimate.com/repos/64f79f2cb94c0076558d5147/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/3dd8c47fb161adc36946/test_coverage)](https://codeclimate.com/repos/64f79f2cb94c0076558d5147/test_coverage)
+[![npm version](https://img.shields.io/npm/v/@enterprise-cmcs/mdct-core/latest.svg)](https://www.npmjs.com/package/@enterprise-cmcs/mdct-core) [![Maintainability](https://api.codeclimate.com/v1/badges/3dd8c47fb161adc36946/maintainability)](https://codeclimate.com/repos/64f79f2cb94c0076558d5147/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/3dd8c47fb161adc36946/test_coverage)](https://codeclimate.com/repos/64f79f2cb94c0076558d5147/test_coverage)
 
 
 ### How to publish this package to npm


### PR DESCRIPTION
### Description
The badge I was using was static and not updating on release. This aims to fix that 


### Related ticket(s)


---
### How to test
1) use semantic release to release a new package version to npm
2) verify that the badge in the readme updates to latest version 


### Important updates
none


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---
