### PR TITLE
fix (publishing from ci): attempt to integrate the publish to npm workflow to slack

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -21,3 +21,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  
+  notify_on_release:
+    runs-on: ubuntu-latest
+    needs: 
+      - build
+    if: success()
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: ${{job.status}}
+          SLACK_ICON: https://github.com/Enterprise-CMCS.png?size=48
+          SLACK_TITLE: A new version of mdct-core has been published to NPM
+          SLACK_USERNAME: ${{ github.repository }} - ${{job.status}}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+        


### PR DESCRIPTION
### Description
this PR aims to add slack integration to cms slack using the newly created slack webhook as a POC


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3134

---
### How to test
on merge publish to main to trigger a new build to publish to npm which in turn should trigger a slack notification


### Important updates
na


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
