### PR TITLE
Adding build failure notification 

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -41,3 +41,18 @@ jobs:
           SLACK_TITLE: "A new version of @enterprise-cmcs/mdct-core ** (${{ env.VERSION}}) ** has been published to NPM."
           SLACK_USERNAME: ${{ github.repository }} - ${{job.status}}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  notify_on_build_failure:
+    runs-on: ubuntu-latest
+    needs: 
+      - build
+    if: failure()
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: ${{job.status}}
+          SLACK_ICON: https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-medium/1f680@2x.png
+          SLACK_TITLE: "The latest Core Build Has Failed"
+          SLACK_USERNAME: ${{ github.repository }} - ${{job.status}}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description
Currently core publishes to a CMS Slack channel when a new version of the package is published to npm. This PR is to add notifications on build failure to the same CMS Slack channel 


### Related ticket(s)
n/a

---
### How to test
run the build that is currently failing because of an aws amplify issue and verify that a build alert is sent to the CMS Slack channel.


### Important updates
na


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
