### PR TITLE
Adding alert for failed unit tests on main

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -42,17 +42,17 @@ jobs:
           SLACK_USERNAME: ${{ github.repository }} - ${{job.status}}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  notify_on_build_failure:
+  notify_on_test_failure:
     runs-on: ubuntu-latest
     needs: 
       - build
-    if: failure()
+    if: ${{ github.ref_name == 'main' && failure() }}
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{job.status}}
           SLACK_ICON: https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-medium/1f680@2x.png
-          SLACK_TITLE: "The latest Core Build Has Failed"
+          SLACK_TITLE: "The latest merge to Core has failed Unit Tests"
           SLACK_USERNAME: ${{ github.repository }} - ${{job.status}}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description
Currently all branches run unit tests which is fine but if a branch is pushed to main and the unit tests fail we want to alert on that. 


### Related ticket(s)
none
---
### How to test
n/a


### Important updates
failed unit tests only on main will publish to slack


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
