### PR TITLE
adding slack notification to notify on pull request for core

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,3 +27,20 @@ jobs:
           PRNUM: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+
+
+  notify_integrations_channel:
+    runs-on: ubuntu-latest
+    needs: 
+      - assignAuthor
+    # avoiding notifications for automated Snyk Pull Requests  
+    if: github.actor != 'mdct-github-service-account'
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: ${{job.status}}
+          SLACK_ICON: https://a.slack-edge.com/production-standard-emoji-assets/14.0/apple-medium/1f680@2x.png
+          SLACK_TITLE: "A new pull request has been created ${{ github.event.pull_request.number }}"
+          SLACK_USERNAME: ${{ github.repository }} - ${{job.status}}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description
This is to establish notifying on pull requests to the mdct integrations channel omitting PR's created by Snyk. note: We will have a separate alerting mechanism for snyk auto deploy failures. 

This is hard to test so I have a temporary channel in cms slack that we'll use for notifications then when all our integrations are done for all the products we will switch the webhook secret in GitHub Actions to be that of the webhook url for our desired integrations channel. 


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3430

---
### How to test
we will merge this then create a pull request with a very minor change to see if the notification behaves as expected. As mentioned the testing workflow for this is not great. 


### Important updates



---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---
