### PR TITLE
Combine prefixes, prefixColors, and colors into a single data structure

### DIFF
--- a/files-to-sync/cli/lib/runner.ts
+++ b/files-to-sync/cli/lib/runner.ts
@@ -1,30 +1,25 @@
 // This file is managed by macpro-mdct-core so if you'd like to change it let's do it there
-import { spawn } from "child_process";
-import path from "path";
+import { spawn } from "node:child_process";
+import path from "node:path";
 
-const prefixes = new Set<string>();
+/**
+ * Maps all known prefixes to an ANSI color code from 1-14, inclusive.
+ * If there are many unique prefixes, colors will repeat.
+ * See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit for color values.
+ */
+const prefixColors = new Map<string, number>();
 let maxPrefixLength = 0;
 
-const prefixColors: Record<string, string> = {};
-// prettier-ignore
-const colors = ["1","2","3","4","5","6","7","8","9","10","11","12","13","14"];
-
 const formattedPrefix = (prefix: string) => {
-  if (!prefixes.has(prefix)) {
-    prefixes.add(prefix);
+  if (!prefixColors.has(prefix)) {
+    prefixColors.set(prefix, (prefixColors.size % 14) + 1);
 
     if (prefix.length > maxPrefixLength) {
       maxPrefixLength = prefix.length;
     }
-
-    const color = colors.shift();
-    if (color) {
-      colors.push(color);
-      prefixColors[prefix] = color;
-    }
   }
 
-  const color = prefixColors[prefix];
+  const color = prefixColors.get(prefix);
   return `\x1b[38;5;${color}m ${prefix.padStart(maxPrefixLength)}|\x1b[0m`;
 };
 


### PR DESCRIPTION
### Description
Pretty small change here - just a refactor around prefix color management. Having a hardcoded list of the integers 1-14 feels a bit silly, and using `.shift()` and `.push()` to cycle through that list feels sillier still.

Replacing the data manipulation with a modulus operator does feel a bit code golf-y, but happily there's room for an explanatory comment & link to explore, while still coming out ahead in terms of code volume.

### Related ticket(s)
n/a

---

### How to test
The colored prefixes for CLI console output should continue to work exactly as before.

### Notes
n/a

---

### Pre-review checklist

- ~[ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary~
- ~[ ] I have updated relevant documentation, if necessary~
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

#### Review

- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
