### PR TITLE
fix delete topics to not throw an error when delete topics doesn't exist

### DIFF
--- a/files-to-sync/cli/commands/delete-topics.ts
+++ b/files-to-sync/cli/commands/delete-topics.ts
@@ -12,22 +12,18 @@ export const delete_topics = async (options: { stage: string }) => {
   );
   const functionName = outputs["DeleteTopicsFunctionName"];
 
-  if (!functionName) {
-    throw new Error(
-      `Could not resolve DeleteTopicsFunctionName from stack ${project}-${options.stage}`
-    );
+  if (functionName) {
+    const payload = JSON.stringify({ project, stage: options.stage });
+
+    const command = new InvokeCommand({
+      FunctionName: functionName,
+      Payload: Buffer.from(payload),
+    });
+
+    const response = await lambdaClient.send(command);
+    const result = Buffer.from(response.Payload || []).toString();
+    console.log("deleteTopics response:", result);
   }
-
-  const payload = JSON.stringify({ project, stage: options.stage });
-
-  const command = new InvokeCommand({
-    FunctionName: functionName,
-    Payload: Buffer.from(payload),
-  });
-
-  const response = await lambdaClient.send(command);
-  const result = Buffer.from(response.Payload || []).toString();
-  console.log("deleteTopics response:", result);
 };
 
 export const deleteTopics = {


### PR DESCRIPTION
### Description

fix delete topics to not throw an error when delete topics doesn't exist

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-

---

### How to test

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
