### PR TITLE
CMDCT-5251 fixing update-code-json workflow

### DIFF
--- a/.github/workflows/update-code-json.yml
+++ b/.github/workflows/update-code-json.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup Go
         uses: actions/setup-go@v6.0.0
-        with:
-          go-version: "1.22"
 
       - name: Install SCC
         run: go install github.com/boyter/scc/v3@v3.5.0

--- a/files-to-sync/.github/workflows/update-code-json.yml
+++ b/files-to-sync/.github/workflows/update-code-json.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup Go
         uses: actions/setup-go@v6.0.0
-        with:
-          go-version: "1.22"
 
       - name: Install SCC
         run: go install github.com/boyter/scc/v3@v3.5.0


### PR DESCRIPTION
### Description

By over-specifying go version our code.json workflow broke. This corrects that.

### Related ticket(s)

CMDCT-5251

---

### How to test
Was tested and worked here:
https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/runs/18200833512

### Notes

NA
---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [x] Design: This work has been reviewed and approved by design, if necessary
- [x] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
