### PR TITLE
CMDCT-5849: add stop localstack in reset command before colima stop

### DIFF
--- a/files-to-sync/cli/commands/reset.ts
+++ b/files-to-sync/cli/commands/reset.ts
@@ -9,6 +9,7 @@ export const reset = {
   handler: async () => {
     await updateEnvFiles();
 
+    await runCommand("Stop localstack", ["localstack", "stop"], ".");
     await runCommand("Stop colima", ["colima", "stop"], ".");
     await runCommand("Delete colima", ["colima", "delete", "--force"], ".");
   },


### PR DESCRIPTION
### Description
Adds `localstack stop` before `colima stop` in the reset command.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5849

---
### How to test
1. In an app repo with the synced CLI change (manually copy over reset.ts locally to test before this is merged).
2. Make sure colima and localstack are running.
3. Run `./run reset`.
4. Confirm the reset output stops localstack before stopping colima, then deletes colima.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
