### PR TITLE
enforce pre-commit 3 minimum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+minimum_pre_commit_version: "3.0.0"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/files-to-sync/.pre-commit-config.yaml
+++ b/files-to-sync/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 # This file is managed by macpro-mdct-core so if you'd like to change it let's do it there
+minimum_pre_commit_version: "3.0.0"
 exclude: "seed-section-base-*"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
### Description
Adds `minimum_pre_commit_version: "3.0.0"` to the core pre-commit config and the core-managed app pre-commit config.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5848

---
### How to test
1. Check out this branch.
2. Run `pre-commit validate-config`.
3. Run `pre-commit validate-config files-to-sync/.pre-commit-config.yaml`.
4. Confirm both commands pass with pre-commit 3 or newer.

Optional verification:
1. Install or run pre-commit 2.x in an isolated environment.
2. Run `pre-commit validate-config files-to-sync/.pre-commit-config.yaml`.
3. Confirm validation fails because pre-commit 3.0.0 or newer is required.


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
