### PR TITLE
CMDCT-5849: make stop localstack idempotent

### DIFF
--- a/files-to-sync/cli/commands/reset.ts
+++ b/files-to-sync/cli/commands/reset.ts
@@ -9,7 +9,11 @@ export const reset = {
   handler: async () => {
     await updateEnvFiles();
 
-    await runCommand("Stop localstack", ["localstack", "stop"], ".");
+    try {
+      await runCommand("Stop localstack", ["localstack", "stop"], ".");
+    } catch {
+      // if localstack is already stopped, don't throw
+    }
     await runCommand("Stop colima", ["colima", "stop"], ".");
     await runCommand("Delete colima", ["colima", "delete", "--force"], ".");
   },


### PR DESCRIPTION
### Description
The addition of `stop localstack` made this script fail if localstack wasn't running.  This PR adds a try with an empty catch to keep reset idempotent.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5849

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
